### PR TITLE
Added "pattern" keyword to backset.yml for SLF4J logging layout.

### DIFF
--- a/server/src/main/java/de/chkal/backset/server/LoggingConfigurator.java
+++ b/server/src/main/java/de/chkal/backset/server/LoggingConfigurator.java
@@ -2,8 +2,6 @@ package de.chkal.backset.server;
 
 import java.util.Map.Entry;
 
-import org.slf4j.LoggerFactory;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -12,10 +10,9 @@ import ch.qos.logback.classic.jul.LevelChangePropagator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
 import de.chkal.backset.server.config.LoggingConfig;
+import org.slf4j.LoggerFactory;
 
 public class LoggingConfigurator {
-
-  private static final String PATTERN = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n";
 
   private LoggingConfig config = new LoggingConfig();
 
@@ -32,7 +29,9 @@ public class LoggingConfigurator {
 
     PatternLayoutEncoder layout = new PatternLayoutEncoder();
     layout.setContext(context);
-    layout.setPattern(PATTERN);
+    if (config != null && config.getPattern() != null) {
+        layout.setPattern(config.getPattern());
+    }
     layout.start();
 
     ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<ILoggingEvent>();

--- a/server/src/main/java/de/chkal/backset/server/config/LoggingConfig.java
+++ b/server/src/main/java/de/chkal/backset/server/config/LoggingConfig.java
@@ -10,6 +10,8 @@ public class LoggingConfig {
 
   private String level = "INFO";
 
+  private String pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n";
+
   private Map<String, String> loggers = new HashMap<>();;
 
   public String getLevel() {
@@ -18,6 +20,14 @@ public class LoggingConfig {
 
   public void setLevel(String level) {
     this.level = level;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(String pattern) {
+    this.pattern = pattern;
   }
 
   public Map<String, String> getLoggers() {


### PR DESCRIPTION
Example:

```
logging:
  level: DEBUG
  pattern: "%d{HH:mm:ss.SSS} [%thread] %-5level %-36logger - %msg%n"
  loggers:
    javax.faces: INFO
```
